### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Esse repositório é um exemplo de aplicação capaz de responder perguntas base
 
 ### Para Executar a aplicação
 
-Tudo está sendo construido em docker, e `docker-compose` é o gerenciador para rodar tudo em desenvolvimento
+Tudo está sendo construído em docker, e `docker-compose` é o gerenciador para rodar tudo em desenvolvimento
 
-```docker-compse up -d```
+```docker-compose up -d```
 
-### Ambiente de desnvolvimento
+### Ambiente de desenvolvimento
 
 Para rodar a aplicação em desenvolvimento, basta rodar o comando abaixo
 
@@ -29,13 +29,13 @@ Para rodar a aplicação sem hot reload, basta rodar o comando abaixo
 - `./data`: A pasta é a persistência dos bancos de dados usados no projeto
 - `./dataset`: A pasta com os arquivos de treinamento do modelo e inicialização do banco de dados
 
-### LLM Llma 3
+### LLM Llama 3
 
 O Meta treinou o Llama 3 com uma contagem de tokens de mais de 15 trilhões de tokens.
 
 O modelo 8B tem um limite de conhecimento de março de 2023.
 
-O modelo 70B tem tem um limite de conhecimento de dezembro de 2023.
+O modelo 70B tem um limite de conhecimento de dezembro de 2023.
 
 Os modelos usam Grouped-Query Attention (GQA).
 
@@ -45,5 +45,5 @@ SFT é uma técnica de treinamento que permite que o modelo seja treinado em um 
 
 - classificador: <https://medium.com/@andsouit/classificador-de-inten%C3%A7%C3%A3o-com-o-tensorflow-f7fbc854f643>
 - LM Studio = interface web para conversar com  o LLM
-- huging face: Tom jobbins
+- Hugging Face: Tom Jobbins
 - repositório de livros de tecnologia: <https://github.com/free-educa/books/blob/main/books/Design_Patterns.pdf>


### PR DESCRIPTION
## Summary
- correct various typos in README

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: f-string expression part cannot include a backslash)*

------
https://chatgpt.com/codex/tasks/task_e_68476296a4948322895791122a06e46d