### PR TITLE
Add document pages API and fix metadata helpers

### DIFF
--- a/src/modules/document/page_metadata.py
+++ b/src/modules/document/page_metadata.py
@@ -84,9 +84,9 @@ class PageMetadata:
         self.chunk = String.split_to_chunks(self.content, 2000)
         self.chunks = int(model['chunks'])
         self.mimetype = model['mimetype']
-        self.phrase = self.split_to_phrase(self.content)
+        self.phrase = String.split_to_phrases(self.content)
         self.phrases = int(model['phrases'])
-        self.paragraph = self.split_to_pargraph(self.content)
+        self.paragraph = String.split_to_pargraphs(self.content)
         self.paragraphs = int(model['paragraphs'])
 
     def to_tuple(self):
@@ -146,9 +146,9 @@ class PageMetadata:
         self.chunk = String.split_to_chunks(self.content, 2000)
         self.chunks = chunks
         self.mimetype = mimetype
-        self.phrase = self.split_to_phrase(self.content)
+        self.phrase = String.split_to_phrases(self.content)
         self.phrases = phrases
-        self.paragraph = self.split_to_pargraph(self.content)
+        self.paragraph = String.split_to_pargraphs(self.content)
         self.paragraphs = paragraphs
 
         return self

--- a/src/routes/document/document.py
+++ b/src/routes/document/document.py
@@ -1,0 +1,17 @@
+from flask import request
+
+from src.modules.document import service as DocService
+from src.modules.response.response import Response
+
+
+async def document_pages_details():
+    path = request.args.get('path', default='', type=str).strip()
+    init = request.args.get('init', default=1, type=int)
+    final = request.args.get('final', default=0, type=int)
+
+    if not path:
+        return Response.error(400, "DOC001", "Parâmetro 'path' é obrigatório").result()
+
+    pages = DocService.pdf_pages_with_details(path, init, final)
+    pages_data = [page.dict() for page in pages]
+    return Response.success(200, pages_data).result()

--- a/src/routes/routes.py
+++ b/src/routes/routes.py
@@ -6,6 +6,7 @@ from flask import Blueprint
 from src.routes.catalog.catalog import catalog_indexer, catalog_list, catalog_search
 from src.routes.completions.completions import completions, completions_history
 from src.routes.corpus.corpus import corpus_generate
+from src.routes.document.document import document_pages_details
 from src.routes.health import health
 
 
@@ -45,3 +46,8 @@ async def api_v1_catalog_indexer():
 @app.route('/api/v1/corpus/generate', methods=['POST'])
 async def api_v1_corpus_generate():
     return await corpus_generate()
+
+
+@app.route('/api/v1/document/pages', methods=['GET'])
+async def api_v1_document_pages_details():
+    return await document_pages_details()

--- a/tests/test_string_utils.py
+++ b/tests/test_string_utils.py
@@ -1,0 +1,22 @@
+import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.utils import string as String
+
+
+def test_split_to_lines():
+    text = "Linha 1\nLinha 2\n\nLinha 3"
+    assert String.split_to_lines(text) == ["Linha 1", "Linha 2", "", "Linha 3"]
+
+
+def test_split_to_phrases():
+    text = "Primeira frase. Segunda frase!" 
+    assert String.split_to_phrases(text) == ["Primeira frase.", "Segunda frase!"]
+
+
+def test_clean():
+    text = " Olá, mundo!!!\n"
+    assert String.clean(text) == "Ola mundo"


### PR DESCRIPTION
## Summary
- fix helper names in `PageMetadata.from_model`
- expose page metadata extraction via new endpoint `/api/v1/document/pages`
- add unit tests for string utility helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840ddcc377483229e18f60c97b6d382